### PR TITLE
feat: provide makefile and utils scripts in bin directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "test": "jest --coverage",
     "travis-deploy-once": "travis-deploy-once"
   },
+  "bin": {
+    "transifex-utils.js": "src/scripts/transifex-utils.js",
+    "transifex-Makefile": "src/scripts/Makefile"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/edx/frontend-i18n.git"

--- a/src/scripts/Makefile
+++ b/src/scripts/Makefile
@@ -1,0 +1,44 @@
+# For more details about the translation jobs, see https://github.com/edx/frontend-i18n/blob/master/docs/how_tos/i18n.rst
+
+transifex_langs = "ar,fr,es_419,zh_CN"
+transifex_utils = ./node_modules/.bin/transifex-utils.js
+transifex_input = ./src/i18n/transifex_input.json
+tx_url1 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transifex_resource)/translation/en/strings/
+tx_url2 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transifex_resource)/source/
+
+requirements:
+	npm install
+
+i18n.extract:
+	# Pulling display strings from .jsx files into .json files...
+	rm -rf $(transifex_temp)
+	npm run-script i18n_extract
+
+i18n.concat:
+	# Gathering JSON messages into one file...
+	$(transifex_utils) $(transifex_temp) $(transifex_input)
+
+extract_translations: | requirements i18n.extract i18n.concat
+
+detect_changed_source_translations:
+	# Checking for changed translations...
+	git diff --exit-code $(transifex_input)
+
+validate-no-uncommitted-package-lock-changes:
+	# Checking for package-lock.json changes...
+	git diff --exit-code package-lock.json
+
+# Push translations to Transifex.  Run make extract_translations first.
+push_translations:
+	# Pushing strings to Transifex...
+	tx push -s
+	# Fetching hashes from Transifex...
+	./node_modules/reactifex/bash_scripts/get_hashed_strings.sh $(tx_url1)
+	# Writing out comments to file...
+	$(transifex_utils) $(transifex_temp) --comments
+	# Pushing comments to Transifex...
+	./node_modules/reactifex/bash_scripts/put_comments.sh $(tx_url2)
+
+# Pull translations from Transifex
+pull_translations:
+	tx pull -f --mode reviewed --language=$(transifex_langs)


### PR DESCRIPTION
The change to package.json will cause `transifex-utils.js` and the `Makefile` to be installed into `node_modules/.bin` in any consuming app as `transifex-utils.js` and `transifex-Makefile`.