### PR TITLE
fix: do not expose FormattedHTMLMessage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,6 @@ If the current locale is an RTL language, adds a "dir=rtl" attribute to the html
 Passthrough components from `react-intl <https://github.com/formatjs/react-intl/wiki/Components>`_.
 
 - **FormattedDate**
-- **FormattedHTMLMessage**
 - **FormattedMessage**
 - **FormattedNumber**
 - **FormattedPlural**

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ export {
   FormattedNumber,
   FormattedPlural,
   FormattedMessage,
-  FormattedHTMLMessage,
   defineMessages,
   IntlProvider,
 } from 'react-intl';


### PR DESCRIPTION
BREAKING CHANGE: FormattedHTMLMessage is not XSS safe and should not be exposed for use.